### PR TITLE
Add Additional Print Columns

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -13,7 +13,6 @@ repo: github.com/kobsio/namespacerole-operator
 resources:
 - api:
     crdVersion: v1
-    namespaced: true
   controller: true
   domain: kobs.io
   kind: NamespaceRole

--- a/api/v1alpha1/namespacerole_types.go
+++ b/api/v1alpha1/namespacerole_types.go
@@ -16,6 +16,8 @@ type NamespaceRoleSpec struct {
 
 // NamespaceRoleStatus defines the observed state of NamespaceRole
 type NamespaceRoleStatus struct {
+	// The label selector to get all ClusterRoles / Roles created by the operator.
+	Selector string `json:"selector,omitempty"`
 	// ClusterRoles is a list of ClusterRoles which were created by the operator.
 	ClusterRoles []NamespaceRoleStatusRole `json:"clusterRoles,omitempty"`
 	// Roles is a list of Roles which were created by the operator.
@@ -32,6 +34,9 @@ type NamespaceRoleStatusRole struct {
 // +kubebuilder:resource:scope=Cluster
 
 // NamespaceRole is the Schema for the namespaceroles API
+// +kubebuilder:printcolumn:name="Namespaces",type=string,JSONPath=`.spec.namespaces`,description="List of namespaces for which the NamespaceRole is used"
+// +kubebuilder:printcolumn:name="Selector",type=string,JSONPath=`.status.selector`,description="Selector to get all ClusterRoles / Roles created by the operator"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time when this NamespaceRole was created"
 type NamespaceRole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/namespacerolebinding_types.go
+++ b/api/v1alpha1/namespacerolebinding_types.go
@@ -22,6 +22,9 @@ type NamespaceRoleBindingSpecRoleRef struct {
 
 // NamespaceRoleBindingStatus defines the observed state of NamespaceRoleBinding
 type NamespaceRoleBindingStatus struct {
+	// The label selector to get all ClusterRoleBindings / RoleBindings created by
+	// the operator.
+	Selector string `json:"selector,omitempty"`
 	// ClusterRoleBindings is a list of ClusterRoleBindings which were created by
 	// the operator.
 	ClusterRoleBindings []NamespaceRoleStatusRoleBinding `json:"clusterRoleBindings,omitempty"`
@@ -39,6 +42,9 @@ type NamespaceRoleStatusRoleBinding struct {
 // +kubebuilder:resource:scope=Cluster
 
 // NamespaceRoleBinding is the Schema for the namespacerolebindings API
+// +kubebuilder:printcolumn:name="NamespaceRole",type=string,JSONPath=`.spec.roleRef.name`,description="The NamespaceRole used by the NamespaceRoleBinding"
+// +kubebuilder:printcolumn:name="Selector",type=string,JSONPath=`.status.selector`,description="Selector to get all ClusterRoleBindings / RoleBindings created by the operator"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time when this NamespaceRoleBinding was created"
 type NamespaceRoleBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/namespacerole-operator/Chart.yaml
+++ b/charts/namespacerole-operator/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: namespacerole-operator
 description: A Kubernetes operator that manages the role-based access control (RBAC) for namespaces
 type: application
-version: 0.2.0
-appVersion: v0.1.0
+version: 0.2.1
+appVersion: v0.1.1

--- a/charts/namespacerole-operator/crds/kobs.io_namespacerolebindings.yaml
+++ b/charts/namespacerole-operator/crds/kobs.io_namespacerolebindings.yaml
@@ -14,7 +14,21 @@ spec:
     singular: namespacerolebinding
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The NamespaceRole used by the NamespaceRoleBinding
+      jsonPath: .spec.roleRef.name
+      name: NamespaceRole
+      type: string
+    - description: Selector to get all ClusterRoleBindings / RoleBindings created
+        by the operator
+      jsonPath: .status.selector
+      name: Selector
+      type: string
+    - description: Time when this NamespaceRoleBinding was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NamespaceRoleBinding is the Schema for the namespacerolebindings
@@ -122,6 +136,11 @@ spec:
                   - namespace
                   type: object
                 type: array
+              selector:
+                description: |-
+                  The label selector to get all ClusterRoleBindings / RoleBindings created by
+                  the operator.
+                type: string
             type: object
         type: object
     served: true

--- a/charts/namespacerole-operator/crds/kobs.io_namespaceroles.yaml
+++ b/charts/namespacerole-operator/crds/kobs.io_namespaceroles.yaml
@@ -14,7 +14,20 @@ spec:
     singular: namespacerole
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: List of namespaces for which the NamespaceRole is used
+      jsonPath: .spec.namespaces
+      name: Namespaces
+      type: string
+    - description: Selector to get all ClusterRoles / Roles created by the operator
+      jsonPath: .status.selector
+      name: Selector
+      type: string
+    - description: Time when this NamespaceRole was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NamespaceRole is the Schema for the namespaceroles API
@@ -130,6 +143,10 @@ spec:
                   - namespace
                   type: object
                 type: array
+              selector:
+                description: The label selector to get all ClusterRoles / Roles created
+                  by the operator.
+                type: string
             type: object
         type: object
     served: true

--- a/internal/controller/namespacerole_controller.go
+++ b/internal/controller/namespacerole_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	kobsiov1alpha1 "github.com/kobsio/namespacerole-operator/api/v1alpha1"
 
@@ -192,6 +193,7 @@ func (r *NamespaceRoleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	namespaceRole.Status.Selector = fmt.Sprintf("%s=%s", selectorLabelKeyNR, namespaceRole.Name)
 	namespaceRole.Status.ClusterRoles = processedClusterRoles
 	namespaceRole.Status.Roles = processedRoles
 

--- a/internal/controller/namespacerolebinding_controller.go
+++ b/internal/controller/namespacerolebinding_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	kobsiov1alpha1 "github.com/kobsio/namespacerole-operator/api/v1alpha1"
 
@@ -197,6 +198,7 @@ func (r *NamespaceRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 	}
 
+	namespaceRoleBinding.Status.Selector = fmt.Sprintf("%s=%s", selectorLabelKeyNRB, namespaceRoleBinding.Name)
 	namespaceRoleBinding.Status.ClusterRoleBindings = processedClusterRoleBindings
 	namespaceRoleBinding.Status.RoleBindings = processedRoleBindings
 


### PR DESCRIPTION
Add additional print columns the the NamespaceRole and
NamespaceRoleBinding CRDs, to show additional information.

For a NamespaceRole we are now showing the list of namespaces and the
selector to get all created ClusterRoles / Roles.

For a NamespaceRoleBinding we are now showing the referenced
NamespaceRole and the selector to get all ClusterRoleBindings /
RoleBindings.
